### PR TITLE
WIP: fix reference_links(), clean everything!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bubblebbs/static/identicons
 __pycache__
+*.swp
 .pytest_cache/
 *.db
 bubblebbs/*.db

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@ __pycache__
 *.db
 bubblebbs/*.db
 .env-file
-dump.rdb
+*.rdb
 .letsencrypt
 *.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ install:
   - docker build . -t bubblebbs
 
 script:
-  - docker run bubblebbs pytest -v "$(pwd):/app"
+  - docker run -v "$(pwd):/app" bubblebbs pytest

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,6 +1,6 @@
 contributors
 
-@lily-mayfield: Project Lead. Majority of work (code, design, etc.). Co-conceptualized with @ACE-Recliner.
-@ACE-Recliner: Original concept, showed @lily-mayfield Web Patio and Minichan as designs to build off of.
+@kawa-kokosowa: Project Lead. Majority of work (code, design, etc.). Co-conceptualized with @ACE-Recliner.
+@ACE-Recliner: Original concept, showed @kawa-kokosowa Web Patio and Minichan as designs to build off of.
 @MaiKawakami: Prominent betatester, planning to use the software for his own site yomu.xyz (Yomuchan)
 @Eiritana: UX/UI advice, feature support, beta tester, stuff breaker, Imageboard Admin and Necromancer, voidspawn.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at lily.m.mayfield@gmail.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at kawa.kokosowa@gmail.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to BubbleBBS
 
-Hello this is [Lily](https://github.com/lily-mayfield) and I want to thank you for reading this file.
+Hello this is [Kawa](https://github.com/kawa-kokosowa) and I want to thank you for reading this file.
 
 ## Git
 
@@ -16,9 +16,9 @@ Please label your issues well!
 
 Here are the easiest ways to contribute right now:
 
-  * [I want your opinion on an idea or question I pose](https://github.com/lily-mayfield/bubblebbs/labels/opinions-wanted)
-  * [Good first issues](https://github.com/lily-mayfield/bubblebbs/labels/good%20first%20issue)
+  * [I want your opinion on an idea or question I pose](https://github.com/kawa-kokosowa/bubblebbs/labels/opinions-wanted)
+  * [Good first issues](https://github.com/kawa-kokosowa/bubblebbs/labels/good%20first%20issue)
 
-In terms of our goals for releases please see [BubbleBBS' milestones](https://github.com/lily-mayfield/bubblebbs/milestones?direction=asc&sort=title&state=open).
+In terms of our goals for releases please see [BubbleBBS' milestones](https://github.com/kawa-kokosowa/bubblebbs/milestones?direction=asc&sort=title&state=open).
 
-Please also check [BubbleBBS issue labels](https://github.com/lily-mayfield/bubblebbs/labels), in case you want to help with something specific.
+Please also check [BubbleBBS issue labels](https://github.com/kawa-kokosowa/bubblebbs/labels), in case you want to help with something specific.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine
-MAINTAINER Lily Mayfield <lily.m.mayfield@gmail.com>
+MAINTAINER Kawa Kokosowa <kawa.kokosowa@gmail.com>
 
 # update!
 RUN apk update

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # BubbleBBS
 
 [![Build
-Status](https://travis-ci.org/lily-mayfield/bubblebbs.svg?branch=master)](https://travis-ci.org/lily-mayfield/bubblebbs)
+Status](https://travis-ci.org/kawa-kokosowa/bubblebbs.svg?branch=master)](https://travis-ci.org/kawa-kokosowa/bubblebbs)
 
 Text BBS/message board which runs [bubblebbs.cafe](http://bubblebbs.cafe).
 
@@ -145,7 +145,7 @@ docker run \
     -e "BBBS_BEHIND_REVERSE_PROXY=1" \
     -e "VIRTUAL_HOST=bubblebbs.cafe" \
     -e "LETSENCRYPT_HOST=bubblebbs.cafe" \
-    -e "LETSENCRYPT_EMAIL=lily.m.mayfield@gmail.com" \
+    -e "LETSENCRYPT_EMAIL=kawa.kokosowa@gmail.com" \
     -e "VIRTUAL_PORT=8081" \
     --publish 8081:80 \
     -d \

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Make sure to change this!
 
 ```
 docker build . -t bubblebbs
-docker run bubblebbs pytest -v "$(pwd):/app"
+docker run -v "$(pwd):/app" bubblebbs pytest
 ```
 
 You only need to run `docker build` once, but you need to run it again when/if

--- a/bubblebbs/config.py
+++ b/bubblebbs/config.py
@@ -18,7 +18,7 @@ SITE_TAGLINE = os.environ.get('BBBS_SITE_TAGLINE', 'some tagline')
 SITE_TITLE = os.environ.get('BBBS_SITE_TAGLINE', 'super title')
 SITE_FOOTER = os.environ.get(
     'BBBS_SITE_FOOTER',
-    '<a href="https://github.com/lily-mayfield/bubblebbs">Powered by BubbleBBS</a>',
+    '<a href="https://github.com/kawa-kokosowa/bubblebbs">Powered by BubbleBBS</a>',
 )
 
 RATELIMIT_STORAGE_URL = os.environ.get('BBBS_RATELIMIT_STORAGE_URL', 'redis://localhost:6379/1')

--- a/bubblebbs/models.py
+++ b/bubblebbs/models.py
@@ -185,14 +185,14 @@ class Post(db.Model):
             else:
                 return '<span class="reflink reflink-invalid">@%d</span>' % at_number
 
-        soup = BeautifulSoup(message, 'html5lib')
+        soup = BeautifulSoup(message, 'html.parser')
         at_link_pattern = re.compile(r'@(\d+)')
-        for text_match in soup.body.find_all(text=True):
+        for text_match in soup.find_all(text=True):
             if re.search(at_link_pattern, text_match) and text_match.parent.name != 'a':
                 new_text = re.sub(at_link_pattern, replace, text_match)
                 text_match.replace_with(new_text)
 
-        return postutils.remove_html5lib_crud(soup)
+        return soup.prettify(formatter=None)
 
     @staticmethod
     def set_bump(form, reply_to, timestamp):

--- a/bubblebbs/models.py
+++ b/bubblebbs/models.py
@@ -1,16 +1,15 @@
 # FIXME: primary key being avoided because you have to do
 # some annoying copypaste code to get primary keys to show
+import copy
 import os
 import re
-import base64
-import zlib
 import pathlib
 import datetime
 from typing import Tuple, Union
 
-import scrypt
 import bleach
 from flask import request
+from bs4 import BeautifulSoup
 from sqlalchemy.exc import (InvalidRequestError, IntegrityError)
 from jinja2 import Markup
 from flask_sqlalchemy import SQLAlchemy
@@ -157,17 +156,18 @@ class Post(db.Model):
         )
         return (not first_post_using_name) or first_post_using_name.tripcode == tripcode
 
-    # TODO: link cross-threads if needbe
+    # FIXME
     @staticmethod
     def reference_links(message, reply_to: int = None) -> str:
-        """Parse @id links"""
+        """Parse @id links.
 
-        pattern = re.compile('\@([0-9]+)')
-        message_with_links = message
-        for match in re.finditer(pattern, message):
+        Explicitly avoids generating links within links.
+
+        """
+
+        def replace(match):
             at_number = int(match.group(1))
 
-            # FIXME: what if not found?
             # Construct the link based on determining if this is
             # a reference to a thread or if it's a reference to a reply
             post_referenced = Post.query.get(at_number)
@@ -180,59 +180,19 @@ class Post(db.Model):
                 link = str(post_referenced.id)
                 valid = True
 
-            replace_pattern = re.compile('\@%d' % at_number)
-
             if valid:
-                replace_with = r'<a href="/threads/%s" class="reflink">@%d</a>' % (link, at_number)
+                return '<a href="/threads/%s" class="reflink">@%d</a>' % (link, at_number)
             else:
-                replace_with = r'<span class="reflink reflink-invalid">@%d</span>' % at_number
+                return '<span class="reflink reflink-invalid">@%d</span>' % at_number
 
-            message_with_links = replace_pattern.sub(
-                replace_with,
-                message_with_links,
-            )
+        soup = BeautifulSoup(message, 'html5lib')
+        at_link_pattern = re.compile(r'@(\d+)')
+        for text_match in soup.body.find_all(text=True):
+            if re.search(at_link_pattern, text_match) and text_match.parent.name != 'a':
+                new_text = re.sub(at_link_pattern, replace, text_match)
+                text_match.replace_with(new_text)
 
-        return message_with_links
-
-    # TODO: move to postutils
-    # FIXME: what if passed a name which contains no tripcode?
-    @staticmethod
-    def make_tripcode(form) -> Tuple[str, str]:
-        """Create a tripcode from the name field of a post.
-
-        Returns:
-            tuple: A two-element tuple containing (in the order of):
-                name without tripcode, tripcode.
-
-        Warning:
-            Must have `this#format` or it will raise an exception
-            related to unpacking.
-
-        """
-
-        # A valid tripcode is a name field containing an octothorpe
-        # that isn't the last character.
-        if not (form.name.data and '#' in form.name.data[:-1]):
-            return form.name.data, None
-
-        name, unhashed_tripcode = form.name.data.split('#', 1)
-
-        # Create the salt
-        if len(name) % 2 == 0:
-            salt = name + config.SECRET_SALT
-        else:
-            salt = config.SECRET_SALT + name
-
-        tripcode = str(
-            base64.b64encode(
-                scrypt.hash(
-                    name + config.SECRET_KEY + unhashed_tripcode,
-                    salt,
-                    buflen=16,
-                ),
-            ),
-        )[2:-1].replace('/', '.').replace('+', '_').replace('=', '-')
-        return name, tripcode
+        return postutils.remove_html5lib_crud(soup)
 
     @staticmethod
     def set_bump(form, reply_to, timestamp):
@@ -281,7 +241,7 @@ class Post(db.Model):
 
         # FIXME: should sanitize first?
         # Prepare info for saving to DB
-        name, tripcode = cls.make_tripcode(form)
+        name, tripcode = postutils.make_tripcode(form.name.data)
         if all([name, tripcode]):
             identicon = postutils.ensure_identicon(tripcode)
             matches_original_use = cls.name_tripcode_matches_original_use(name, tripcode)

--- a/bubblebbs/postutils.py
+++ b/bubblebbs/postutils.py
@@ -151,7 +151,7 @@ def parse_markdown(message: str, allow_all=False, unique_slug=None) -> str:
                 'h6': ['id'],
                 'li': ['id'],
                 'sup': ['id'],
-                'a': ['href'],
+                'a': ['href', 'class'],
 		'iframe': ['allow', 'width', 'height', 'src', 'frameborder', 'allowfullscreen'],
             },
             styles={},
@@ -162,11 +162,6 @@ def parse_markdown(message: str, allow_all=False, unique_slug=None) -> str:
     md = markdown.Markdown(extensions=extensions)
     return md.convert(message)
 
-
-def remove_html5lib_crud(soup) -> str:
-    # Preserve formatting as much as possible, but also remove the
-    # junk <html>, <body>, etc., that html5lib adds to all soups...
-    return soup.body.prettify(formatter=None)[len('<body>'):len('</body>')]
 
 def add_domains_to_link_texts(html_message: str) -> str:
     """Append domain in parenthese to all link texts.
@@ -189,7 +184,7 @@ def add_domains_to_link_texts(html_message: str) -> str:
 
     """
 
-    soup = BeautifulSoup(html_message, 'html5lib')
+    soup = BeautifulSoup(html_message, 'html.parser')
 
     # find every link in the message which isn't a "reflink"
     # and append `(thedomain)` to the end of each's text
@@ -206,9 +201,7 @@ def add_domains_to_link_texts(html_message: str) -> str:
         new_tag.string = '%s (%s)' % (anchor.string, domain)
         anchor.replace_with(new_tag)
 
-    # Return, stripped of the erroneous fluff elements html5lib
-    # likes to nest everything into
-    return remove_html5lib_crud(soup)
+    return soup.prettify(formatter=None)
 
 
 def ensure_identicon(tripcode: str) -> str:

--- a/bubblebbs/runserver.py
+++ b/bubblebbs/runserver.py
@@ -5,5 +5,6 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from bubblebbs import app
 
 
-app.app.debug = True
-app.app.run(host='0.0.0.0', port=8080, debug=True)
+app = app.create_app()
+app.debug = True
+app.run(host='0.0.0.0', port=8080, debug=True)

--- a/docker_includes/entrypoint.sh
+++ b/docker_includes/entrypoint.sh
@@ -15,7 +15,7 @@ if [ "$1" == "debug" ]; then
 elif [ "$1" == "pytest" ]; then
     echo "Starting in pytest mode!"
     cd /app
-    pytest -vv tests
+    pytest -vvvv tests
 else
     echo "Running app in production mode!"
     nginx && uwsgi --ini /app.ini

--- a/tests/parsing/add_domains_to_link_texts_parsed.txt
+++ b/tests/parsing/add_domains_to_link_texts_parsed.txt
@@ -1,0 +1,11 @@
+Have you read
+<a class="heck external-link" href="http://www.example.org/somebook.pdf">
+ Some Book (www.example.org)
+</a>
+?
+I thought it was similar to
+<a class="internal-link" href="/downloads/anotherbook.pdf">
+ Another
+Book (internal link)
+</a>
+, which is hosted on this website.

--- a/tests/parsing/add_domains_to_link_texts_unparsed.txt
+++ b/tests/parsing/add_domains_to_link_texts_unparsed.txt
@@ -1,0 +1,3 @@
+Have you read <a href="http://www.example.org/somebook.pdf" class="heck">Some Book</a>?
+I thought it was similar to <a href="/downloads/anotherbook.pdf">Another
+Book</a>, which is hosted on this website.

--- a/tests/parsing/parse_markdown_parsed.txt
+++ b/tests/parsing/parse_markdown_parsed.txt
@@ -1,0 +1,51 @@
+<ul>
+<li><a href="#example-markdown-post">Example Markdown Post</a><ul>
+<li><a href="#h3">H3</a><ul>
+<li><a href="#h4">H4</a><ul>
+<li><a href="#h5">H5</a><ul>
+<li><a href="#h6">H6</a></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</li>
+<li><a href="#citations">Citations</a></li>
+</ul>
+</li>
+</ul>
+
+<h2 id="example-markdown-post">Example Markdown Post</h2>
+<p>This is an example Markdown post. This is a normal paragraph. Oh look, this paragraph <a href="http://example.org">has a link!</a></p>
+<p><em>This is a bold paragraph.</em></p>
+<p><em>This paragraph is italic.</em></p>
+<p>To use codeblocks just use three of these to open and close: `</p>
+<h3 id="h3">H3</h3>
+<p>Here&rsquo;s some more text and oh look a citation.<sup id="fnrefcats-1"><a class="footnote-ref" href="#fncats-1">1</a></sup></p>
+<h4 id="h4">H4</h4>
+<p>If you do &hellip; it gets turned into a proper ellipsis.</p>
+<p>The HTML specification<br>
+is maintained by the W3C. This paragraph shows off abbreviations.</p>
+<h5 id="h5">H5</h5>
+<p>If use you use &rdquo; they get turned into left and right quotes.</p>
+<p>Here are some definition lists&hellip;</p>
+<dl>
+<dt>Apple</dt>
+<dd>Pomaceous fruit of plants of the genus Malus in<br>
+the family Rosaceae.</dd>
+<dt>Orange</dt>
+<dd>The fruit of an evergreen tree of the genus Citrus.</dd>
+</dl>
+<h6 id="h6">H6</h6>
+<p>If you use apostrophes &lsquo; they get turned into the proper-facing version.</p>
+<p>This is<br>
+a single paragraph<br>
+because of nl2br</p>
+<h3 id="citations">Citations</h3>
+
+
+<ol>
+<li id="fncats-1">
+<p>A rad person?qq3936677670287331zz?<a class="footnote-backref" href="#fnrefcats-1">?zz1337820767766393qq?</a></p>
+</li>
+</ol>

--- a/tests/parsing/parse_markdown_unparsed.txt
+++ b/tests/parsing/parse_markdown_unparsed.txt
@@ -1,0 +1,51 @@
+[TOC]
+
+## Example Markdown Post
+
+This is an example Markdown post. This is a normal paragraph. Oh look, this paragraph [has a link!](http://example.org)
+
+*This is a bold paragraph.*
+
+_This paragraph is italic._
+
+To use codeblocks just use three of these to open and close: `
+
+### H3
+
+Here's some more text and oh look a citation.[^1]
+
+#### H4
+
+If you do ... it gets turned into a proper ellipsis.
+
+The HTML specification
+is maintained by the W3C. This paragraph shows off abbreviations.
+
+*[HTML]: Hyper Text Markup Language
+*[W3C]:  World Wide Web Consortium
+
+##### H5
+
+If use you use " they get turned into left and right quotes.
+
+Here are some definition lists...
+
+Apple
+:   Pomaceous fruit of plants of the genus Malus in
+    the family Rosaceae.
+
+Orange
+:   The fruit of an evergreen tree of the genus Citrus.
+
+###### H6
+
+If you use apostrophes ' they get turned into the proper-facing version.
+
+This is
+a single paragraph
+because of nl2br
+
+### Citations
+
+[^1]: A rad person
+

--- a/tests/parsing/reference_links_parsed.txt
+++ b/tests/parsing/reference_links_parsed.txt
@@ -1,0 +1,17 @@
+guess what
+
+<a href="/threads/1#2" class="reflink">@2</a>
+
+ur good
+
+@@asdf
+
+<a href="/threads/1" class="reflink">@1</a>
+<a href="lol">
+ @2
+</a>
+your @@ @ 33
+
+afsoiu wfkj wfe <a href="/threads/1" class="reflink">@1</a> ajs;lfkjasf<a href="/threads/1" class="reflink">@1</a>
+
+<a href="/threads/1" class="reflink">@1</a>f

--- a/tests/parsing/reference_links_unparsed.txt
+++ b/tests/parsing/reference_links_unparsed.txt
@@ -1,0 +1,17 @@
+guess what
+
+@2
+
+ur good
+
+@@asdf
+
+@1
+
+<a href="lol">@2</a>
+
+your @@ @ 33
+
+afsoiu wfkj wfe @1 ajs;lfkjasf@1
+
+@1f

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,51 +1,87 @@
+import os
+import unittest
+
+from bubblebbs import config
+from bubblebbs import app
+from bubblebbs import moderate
 from bubblebbs import models
 
-class TestPost:
-    def test_make_tripcode(self):
-        assert ('bleh', 'ZoGgoBAnxOWv8QiHwA9A') == models.Post.make_tripcode('bleh#lol')
 
+class TestPost(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
+        cls.app = app.create_app()
+        cls.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+
+    def setUp(self):
+        self.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+        self.app.config['TESTING'] = True
+        self.app.config['WTF_CSRF_ENABLED'] = False
+        self.app.config['RATELIMIT_ENABLED'] = False
+        self.test_app = self.app.test_client()
+        app.limiter.enabled = False
+
+        response = self.test_app.get('/')
+        assert response.status_code == 200
+
+        response = self.test_app.post('/threads/new', data={'name': 'uboa', 'message': 'lol'})
+        assert response.status_code == 302
+
+        response = self.test_app.post(
+            '/replies/new',
+            data={'name': 'uboa', 'message': 'heckers', 'reply_to': 1},
+        )
+        assert response.status_code == 302
+
+    def tearDown(self):
+        os.close(self.db_fd)
+        os.unlink(self.app.config['SQLALCHEMY_DATABASE_URI'])
+
+    # FIXME: needs test demo posts...
     def test_reference_links(self):
         test_links_message = '''
         guess what
 
-        >>22
+        @2
 
         ur good
 
-        >>asdf
+        @@asdf
 
-        >>3
+        @1
 
-        >dlasjf;lkjsd
+        <a href="lol">@2</a>
 
-        >3
+        your @@ @ 33
 
-        your >> butt >> 33
+        afsoiu wfkj wfe @1 ajs;lfkjasf@1
 
-        afsoiu wfkj wfe >>22 ajs;lfkjasf>>22
-
-        >>33f
+        @1f
         '''
-        hopefully_nicely_linked = models.Post.reference_links(test_links_message, 42)
+        with self.app.app_context():
+            hopefully_nicely_linked = models.Post.reference_links(test_links_message, 42)
+
         correctly_parsed_nicely_linked = '''
         guess what
 
-        <a href="/threads/42#22">&gt;&gt;22</a>
+        <a href="/threads/1#2" class="reflink">@2</a>
 
         ur good
 
-        &gt;&gt;asdf
+        @@asdf
 
-        <a href="/threads/42#3">&gt;&gt;3</a>
+        <a href="lol">@2</a>
 
-        &gt;dlasjf;lkjsd
+        <a href="/threads/1" class="reflink">@1</a>
 
-        &gt;3
+        @dlasjf;lkjsd
 
-        your &gt;&gt; butt &gt;&gt; 33
+        your @@ @ 33
 
-        afsoiu wfkj wfe <a href="/threads/42#22">&gt;&gt;22</a> ajs;lfkjasf<a href="/threads/42#22">&gt;&gt;22</a>
+        afsoiu wfkj wfe <a href="/threads/1#2" class="reflink">@2</a> ajs;lfkjasf<a href="/threads/1" class="reflink">@1</a>
 
-        <a href="/threads/42#33">&gt;&gt;33</a>f
+        <a href="/threads/1" class="reflink">@1</a>f
         '''
         assert hopefully_nicely_linked == correctly_parsed_nicely_linked

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -35,53 +35,19 @@ class TestPost(unittest.TestCase):
         )
         assert response.status_code == 302
 
-    def tearDown(self):
-        os.close(self.db_fd)
-        os.unlink(self.app.config['SQLALCHEMY_DATABASE_URI'])
-
-    # FIXME: needs test demo posts...
     def test_reference_links(self):
-        test_links_message = '''
-        guess what
+        """Test the insertion of @2 style post reference links."""
 
-        @2
+        # The raw post text we hope to turn into something correctly parsed
+        with open('tests/parsing/reference_links_unparsed.txt') as f:
+            test_links_message = f.read()
 
-        ur good
-
-        @@asdf
-
-        @1
-
-        <a href="lol">@2</a>
-
-        your @@ @ 33
-
-        afsoiu wfkj wfe @1 ajs;lfkjasf@1
-
-        @1f
-        '''
+        # We feed the raw post text and hope it's correctly parsed
         with self.app.app_context():
             hopefully_nicely_linked = models.Post.reference_links(test_links_message, 42)
 
-        correctly_parsed_nicely_linked = '''
-        guess what
+        # What the post text *should* be after parsing it
+        with open('tests/parsing/reference_links_parsed.txt') as f:
+            correctly_parsed_nicely_linked = f.read()
 
-        <a href="/threads/1#2" class="reflink">@2</a>
-
-        ur good
-
-        @@asdf
-
-        <a href="lol">@2</a>
-
-        <a href="/threads/1" class="reflink">@1</a>
-
-        @dlasjf;lkjsd
-
-        your @@ @ 33
-
-        afsoiu wfkj wfe <a href="/threads/1#2" class="reflink">@2</a> ajs;lfkjasf<a href="/threads/1" class="reflink">@1</a>
-
-        <a href="/threads/1" class="reflink">@1</a>f
-        '''
         assert hopefully_nicely_linked == correctly_parsed_nicely_linked

--- a/tests/test_postutils.py
+++ b/tests/test_postutils.py
@@ -3,6 +3,10 @@ from textwrap import dedent
 from bubblebbs import postutils
 
 
+def test_make_tripcode():
+    assert ('bleh', 'CWj74YsG7iMjTMMxPvhZpA--') == postutils.make_tripcode('bleh#lol')
+
+
 # FIXME: how the heck can i test this when it generates time?
 def test_parse_markdown():
     markdown_to_parse = """

--- a/tests/test_postutils.py
+++ b/tests/test_postutils.py
@@ -1,5 +1,3 @@
-from textwrap import dedent
-
 from bubblebbs import postutils
 
 
@@ -7,130 +5,32 @@ def test_make_tripcode():
     assert ('bleh', 'CWj74YsG7iMjTMMxPvhZpA--') == postutils.make_tripcode('bleh#lol')
 
 
-# FIXME: how the heck can i test this when it generates time?
 def test_parse_markdown():
-    markdown_to_parse = """
-	[TOC]
 
-	## Example Markdown Post
+    # The raw post text we hope to turn into something correctly parsed
+    with open('tests/parsing/parse_markdown_unparsed.txt') as f:
+        markdown_to_parse = f.read()
 
-	This is an example Markdown post. This is a normal paragraph. Oh look, this paragraph [has a link!](http://example.org)
+    # What the post text *should* be after parsing it
+    with open('tests/parsing/parse_markdown_parsed.txt') as f:
+        correct_html_output = f.read()
 
-	*This is a bold paragraph.*
-
-	_This paragraph is italic._
-
-	To use codeblocks just use three of these to open and close: `
-
-	### H3
-
-	Here's some more text and oh look a citation.[^1]
-
-	#### H4
-
-	If you do ... it gets turned into a proper ellipsis.
-
-	The HTML specification
-	is maintained by the W3C. This paragraph shows off abbreviations.
-
-	*[HTML]: Hyper Text Markup Language
-	*[W3C]:  World Wide Web Consortium
-
-	##### H5
-
-	If use you use " they get turned into left and right quotes.
-
-	Here are some definition lists...
-
-	Apple
-	:   Pomaceous fruit of plants of the genus Malus in
-	    the family Rosaceae.
-
-	Orange
-	:   The fruit of an evergreen tree of the genus Citrus.
-
-	###### H6
-
-	If you use apostrophes ' they get turned into the proper-facing version.
-
-	This is
-	a single paragraph
-	because of nl2br
-
-	### Citations
-
-	[^1]: A rad person
-	"""
-    markdown_to_parse = dedent(dedent(markdown_to_parse).strip())
-
-    html_result_hopefully = """
-	<ul>
-	<li><a href="#example-markdown-post">Example Markdown Post</a><ul>
-	<li><a href="#h3">H3</a><ul>
-	<li><a href="#h4">H4</a><ul>
-	<li><a href="#h5">H5</a><ul>
-	<li><a href="#h6">H6</a></li>
-	</ul>
-	</li>
-	</ul>
-	</li>
-	</ul>
-	</li>
-	<li><a href="#citations">Citations</a></li>
-	</ul>
-	</li>
-	</ul>
-
-	<h2 id="example-markdown-post">Example Markdown Post</h2>
-	<p>This is an example Markdown post. This is a normal paragraph. Oh look, this paragraph <a href="http://example.org">has a link!</a></p>
-	<p><em>This is a bold paragraph.</em></p>
-	<p><em>This paragraph is italic.</em></p>
-	<p>To use codeblocks just use three of these to open and close: `</p>
-	<h3 id="h3">H3</h3>
-	<p>Here&rsquo;s some more text and oh look a citation.<sup id="fnrefcats-1"><a href="#fncats-1">1</a></sup></p>
-	<h4 id="h4">H4</h4>
-	<p>If you do &hellip; it gets turned into a proper ellipsis.</p>
-	<p>The HTML specification<br>
-	is maintained by the W3C. This paragraph shows off abbreviations.</p>
-	<h5 id="h5">H5</h5>
-	<p>If use you use &rdquo; they get turned into left and right quotes.</p>
-	<p>Here are some definition lists&hellip;</p>
-	<dl>
-	<dt>Apple</dt>
-	<dd>Pomaceous fruit of plants of the genus Malus in<br>
-	the family Rosaceae.</dd>
-	<dt>Orange</dt>
-	<dd>The fruit of an evergreen tree of the genus Citrus.</dd>
-	</dl>
-	<h6 id="h6">H6</h6>
-	<p>If you use apostrophes &lsquo; they get turned into the proper-facing version.</p>
-	<p>This is<br>
-	a single paragraph<br>
-	because of nl2br</p>
-	<h3 id="citations">Citations</h3>
-
-
-	<ol>
-	<li id="fncats-1">
-	<p>A rad person?qq3936677670287331zz?<a href="#fnrefcats-1">?zz1337820767766393qq?</a></p>
-	</li>
-	</ol>
-	"""
-    html_result_hopefully = dedent(html_result_hopefully).strip()
-
-    assert postutils.parse_markdown(markdown_to_parse, unique_slug='cats') == html_result_hopefully
+    # Hopefully this parses correctly!
+    # FIXME: using strip() on correct_html_output is bad!
+    hopefully_correct_output = postutils.parse_markdown(markdown_to_parse, unique_slug='cats')
+    assert hopefully_correct_output == correct_html_output.strip()
 
 
 def test_add_domains_to_link_texts():
-    message_to_parse = """
-    Have you read <a href="http://www.example.org/somebook.pdf" class="heck">Some Book</a>?
-    I thought it was similar to <a href="/downloads/anotherbook.pdf">Another
-    Book</a>, which is hosted on this website.
-    """.strip()
-    parsed_message = """
-    Have you read <a class="heck external-link" href="http://www.example.org/somebook.pdf">Some Book (www.example.org)</a>?
-    I thought it was similar to <a class="internal-link" href="/downloads/anotherbook.pdf">Another
-    Book (internal link)</a>, which is hosted on this website.
-    """.strip()
 
-    assert postutils.add_domains_to_link_texts(message_to_parse) == parsed_message
+    # The raw post text we hope to turn into something correctly parsed
+    with open('tests/parsing/add_domains_to_link_texts_unparsed.txt') as f:
+        message_to_parse = f.read()
+
+    # What the post text *should* be after parsing it
+    with open('tests/parsing/add_domains_to_link_texts_parsed.txt') as f:
+        correctly_parsed_message = f.read()
+
+    # Hoping this parses correctly using the raw post text!
+    hopefully_correctly_parsed = postutils.add_domains_to_link_texts(message_to_parse)
+    assert hopefully_correctly_parsed == correctly_parsed_message


### PR DESCRIPTION
Flagged as WIP because tests are currently broken
due to BeautifulSoup messing with formatting.

Update `README.md` to fix an erroneous Docker
command.

Update travis to reflect removal of Docker
scripts/new recommended commands.

add create_app(): change code to use this flask
app factory. Implement flask blueprint.
Modify `runserver.py` to reflect this. Had to
change `url_for` to reference the blueprint name,
e.g., `manage_cookie` -> `app.manage_cookie`.

Change the flask import line in app.py to be
multi-line since there's about 1000 imports. :p

Fix reference_links() issue where it would add
a reference link inside a link, e.g., [see u
@3:30](http://example.org/events/234) would get
turned into something like <a
href="http://example.org/events/234">see u <a
href="/threads/3">@3</a>:30</a>.

Move make_tripcode() to postutils.

Use a more elegant way of trimming the html5lib
fat.

Add more verbosity to pytest mode (docker
entrypoint.sh).

Implement real model tests. Work in progress.
Tests currently broken because BeautifulSoup is
messing with formatting too much.  Start testing
postutils.

Summary of changes

Why you think this addition is needed/good

Does this address any issues? Please reference them like this: #1
