### PR TITLE
move reference_links() to postutils

### DIFF
--- a/bubblebbs/postutils.py
+++ b/bubblebbs/postutils.py
@@ -22,6 +22,44 @@ from markdown.extensions.wikilinks import WikiLinkExtension
 from . import config
 
 
+def reference_links(post_model, message: str, reply_to: int = None) -> str:
+    """Parse @id links.
+
+    Explicitly avoids generating links within links.
+
+    """
+
+    def replace(match):
+        at_number = int(match.group(1))
+
+        # Construct the link based on determining if this is
+        # a reference to a thread or if it's a reference to a reply
+        post_referenced = post_model.query.get(at_number)
+        if not post_referenced:
+            valid = False
+        elif post_referenced.reply_to:
+            link = '%d#%d' % (post_referenced.reply_to, post_referenced.id)
+            valid = True
+        else:
+            link = str(post_referenced.id)
+            valid = True
+
+        if valid:
+            return '<a href="/threads/%s" class="reflink">@%d</a>' % (link, at_number)
+        else:
+            return '<span class="reflink reflink-invalid">@%d</span>' % at_number
+
+    soup = BeautifulSoup(message, 'html.parser')
+    at_link_pattern = re.compile(r'@(\d+)')
+    for text_match in soup.find_all(text=True):
+        if re.search(at_link_pattern, text_match) and text_match.parent.name != 'a':
+            new_text = re.sub(at_link_pattern, replace, text_match)
+            text_match.replace_with(new_text)
+
+    return soup.prettify(formatter=None)
+
+
+
 # FIXME: what if passed a name which contains no tripcode?
 def make_tripcode(form_name: str) -> Tuple[str, str]:
     """Create a tripcode from the name field of a post.

--- a/tests/test_postutils.py
+++ b/tests/test_postutils.py
@@ -1,4 +1,28 @@
 from bubblebbs import postutils
+from bubblebbs import models
+
+from . import testutils
+
+
+class TestDatabasePostUtils(testutils.DatabaseTest):
+    """Test post utilities which require a database connection."""
+
+    def test_reference_links(self):
+        """Test the insertion of @2 style post reference links."""
+
+        # The raw post text we hope to turn into something correctly parsed
+        with open('tests/parsing/reference_links_unparsed.txt') as f:
+            test_links_message = f.read()
+
+        # We feed the raw post text and hope it's correctly parsed
+        with self.app.app_context():
+            hopefully_nicely_linked = postutils.reference_links(models.Post, test_links_message, 42)
+
+        # What the post text *should* be after parsing it
+        with open('tests/parsing/reference_links_parsed.txt') as f:
+            correctly_parsed_nicely_linked = f.read()
+
+        assert hopefully_nicely_linked == correctly_parsed_nicely_linked
 
 
 def test_make_tripcode():

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -1,13 +1,11 @@
-import os
 import unittest
 
-from bubblebbs import config
 from bubblebbs import app
-from bubblebbs import moderate
-from bubblebbs import models
+from bubblebbs import config
 
 
-class TestPost(unittest.TestCase):
+# FIXME: why does this have setUpClass and setUp?
+class DatabaseTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -35,19 +33,4 @@ class TestPost(unittest.TestCase):
         )
         assert response.status_code == 302
 
-    def test_reference_links(self):
-        """Test the insertion of @2 style post reference links."""
 
-        # The raw post text we hope to turn into something correctly parsed
-        with open('tests/parsing/reference_links_unparsed.txt') as f:
-            test_links_message = f.read()
-
-        # We feed the raw post text and hope it's correctly parsed
-        with self.app.app_context():
-            hopefully_nicely_linked = models.Post.reference_links(test_links_message, 42)
-
-        # What the post text *should* be after parsing it
-        with open('tests/parsing/reference_links_parsed.txt') as f:
-            correctly_parsed_nicely_linked = f.read()
-
-        assert hopefully_nicely_linked == correctly_parsed_nicely_linked


### PR DESCRIPTION
create testutils by introducing DatabaseTest
class, to be inherited by any Test* class which
requires the use of a database for testing
purposes.

Make reference_links() accept the Post model as
its first argument. The reason reference_links()
was moved to postutils was for clearer separation
of module responsibilities. It didn't seem right
that so much post transmorgification ocurred in
the models module/in Post model.

Remove `test_models` because the only thing it
was testing was reference_links() which is now
a postutils function.

Summary of changes

Why you think this addition is needed/good

Does this address any issues? Please reference them like this: #1
